### PR TITLE
Added the 'Classic' (old defaults) theme.

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1,5 +1,6 @@
 # Please order list alphanumerically
 atelier: https://github.com/atelierbram/base16-atelier-schemes
+classic: https://github.com/detly/base16-classic-scheme
 default: https://github.com/chriskempson/base16-default-schemes
 dracula: https://github.com/mikebarkmin/base16-dracula-scheme
 github: https://github.com/Defman21/base16-github-scheme


### PR DESCRIPTION
See [issue #35 on the Textmate theme](https://github.com/chriskempson/base16-textmate/issues/35). I reconstructed the older defaults as a "classic" theme, because I like the slightly darker/more saturated palette.