### PR TITLE
Add solarflare as a maintained scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -19,6 +19,7 @@ one-light: https://github.com/purpleKarrot/base16-one-light-scheme
 onedark: https://github.com/tilal6991/base16-onedark-scheme
 porple: https://github.com/AuditeMarlow/base16-porple-scheme
 rebecca: https://github.com/vic/base16-rebecca
+solarflare: https://github.com/mnussbaum/base16-solarflare-scheme
 summerfruit: https://github.com/cscorley/base16-summerfruit-scheme
 tomorrow: https://github.com/chriskempson/base16-tomorrow-scheme
 twilight: https://github.com/hartbit/base16-twilight-scheme


### PR DESCRIPTION
I've rehosted the unmaintained solarflare at https://github.com/mnussbaum/base16-solarflare-scheme, with the permission of @chuckharmston the original author.

This PR adds it to the scheme list