### PR TITLE
Update list.yaml to include base16-black-metal

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1,5 +1,6 @@
 # Please order list alphanumerically
 atelier: https://github.com/atelierbram/base16-atelier-schemes
+black-metal: https://github.com/metalelf0/base16-black-metal-scheme
 brushtrees: https://github.com/WhiteAbeLincoln/base16-brushtrees-scheme
 circus: https://github.com/stepchowfun/base16-circus-scheme
 classic: https://github.com/detly/base16-classic-scheme


### PR DESCRIPTION
[base16-black-metal](https://github.com/metalelf0/base16-black-metal-scheme) is a set of colorschemes inspired by black metal bands. Each of them is crafted with colors coming from album covers from inspirational albums. It received a good welcome on `/r/unixporn`, so I thought it could be a good addition to the schemes list.