### PR TITLE
Add base16-heetch-scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -12,6 +12,7 @@ dracula: https://github.com/dracula/base16-dracula-scheme
 fruit-soda: https://github.com/jozip/base16-fruit-soda-scheme
 github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
+heetch: https://github.com/tealeg/base16-heetch-scheme
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme
 materia: https://github.com/Defman21/base16-materia


### PR DESCRIPTION
I'd like to have my "Heetch" scheme included in the base16 repo.