### PR TITLE
Add synth-midnight scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -15,6 +15,7 @@ github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
 horizon: https://github.com/michael-ball/base16-horizon-scheme
+horizon-alt: https://github.com/michael-ball/base16-horizon-alt-scheme
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme
 materia: https://github.com/Defman21/base16-materia

--- a/list.yaml
+++ b/list.yaml
@@ -13,8 +13,8 @@ dracula: https://github.com/dracula/base16-dracula-scheme
 fruit-soda: https://github.com/jozip/base16-fruit-soda-scheme
 github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
-horizon: https://github.com/michael-ball/base16-horizon-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
+horizon: https://github.com/michael-ball/base16-horizon-scheme
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme
 materia: https://github.com/Defman21/base16-materia

--- a/list.yaml
+++ b/list.yaml
@@ -33,6 +33,7 @@ snazzy: https://github.com/h404bi/base16-snazzy-scheme
 solarflare: https://github.com/mnussbaum/base16-solarflare-scheme
 solarized: https://github.com/aramisgithub/base16-solarized-scheme
 summerfruit: https://github.com/cscorley/base16-summerfruit-scheme
+synth-midnight: https://github.com/michael-ball/base16-synth-midnight-scheme
 tomorrow: https://github.com/chriskempson/base16-tomorrow-scheme
 twilight: https://github.com/hartbit/base16-twilight-scheme
 unikitty: https://github.com/joshwlewis/base16-unikitty

--- a/list.yaml
+++ b/list.yaml
@@ -13,6 +13,7 @@ dracula: https://github.com/dracula/base16-dracula-scheme
 fruit-soda: https://github.com/jozip/base16-fruit-soda-scheme
 github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
+horizon: https://github.com/michael-ball/base16-horizon-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme

--- a/list.yaml
+++ b/list.yaml
@@ -15,7 +15,6 @@ github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
 horizon: https://github.com/michael-ball/base16-horizon-scheme
-horizon-alt: https://github.com/michael-ball/base16-horizon-alt-scheme
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme
 materia: https://github.com/Defman21/base16-materia


### PR DESCRIPTION
I've created a new base16 scheme based on the artwork for The Midnight's "Nocturnal" album. Could it could be added to the scheme list?