### PR TITLE
Add sandcastle theme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -29,6 +29,7 @@ papercolor: https://github.com/jonleopard/base16-papercolor-scheme
 porple: https://github.com/AuditeMarlow/base16-porple-scheme
 purpledream: https://github.com/archmalet/base16-purpledream-scheme
 rebecca: https://github.com/vic/base16-rebecca
+sandcastle: https://github.com/gessig/base16-sandcastle-scheme
 snazzy: https://github.com/h404bi/base16-snazzy-scheme
 solarflare: https://github.com/mnussbaum/base16-solarflare-scheme
 solarized: https://github.com/aramisgithub/base16-solarized-scheme


### PR DESCRIPTION
Sandcastle is a base16 color scheme that is a mashup of Darktooth, Zerodark, and base16-atelier-savanna.  Screenshots are available at https://github.com/gessig/base16-sandcastle-scheme.