### PR TITLE
add base16-summercamp

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -32,6 +32,7 @@ rebecca: https://github.com/vic/base16-rebecca
 snazzy: https://github.com/h404bi/base16-snazzy-scheme
 solarflare: https://github.com/mnussbaum/base16-solarflare-scheme
 solarized: https://github.com/aramisgithub/base16-solarized-scheme
+summercamp: https://github.com/zoefiri/base16-summercamp
 summerfruit: https://github.com/cscorley/base16-summerfruit-scheme
 tomorrow: https://github.com/chriskempson/base16-tomorrow-scheme
 twilight: https://github.com/hartbit/base16-twilight-scheme


### PR DESCRIPTION
base16-summercamp is a theme I recently wrote for personal use, thought I'd submit it. Screenshots are shown in the repo @ https://github.com/zoefiri/base16-summercamp