### PR TITLE
Add correct version of Nord scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -28,7 +28,7 @@ materialtheme: https://github.com/ntpeters/base16-materialtheme-scheme
 material-vivid: https://github.com/joshyrobot/base16-material-vivid-scheme
 mellow: https://github.com/gidsi/base16-mellow-scheme
 mexico-light: https://github.com/drzel/base16-mexico-light-scheme
-nord: https://github.com/8-uh/base16-nord-scheme
+nord: https://github.com/spejamchr/base16-nord-scheme
 nova: https://github.com/gessig/base16-nova-scheme
 one-light: https://github.com/purpleKarrot/base16-one-light-scheme
 onedark: https://github.com/tilal6991/base16-onedark-scheme


### PR DESCRIPTION
As pointed out in chriskempson/base16-shell#180, the current colors in the Nord colorscheme do not conform to the actual colors specified by the Nord project, with e.g. green being red and red being blue.

Luckily, @spejamchr has a forked repo where this is fixed, so it should be updated here as well.