### PR TITLE
Add katy scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -30,6 +30,7 @@ horizon: https://github.com/michael-ball/base16-horizon-scheme
 humanoid: https://github.com/humanoid-colors/base16-humanoid-schemes
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme
+katy: https://github.com/gessig/base16-katy-scheme
 materia: https://github.com/Defman21/base16-materia
 materialtheme: https://github.com/ntpeters/base16-materialtheme-scheme
 material-vivid: https://github.com/joshyrobot/base16-material-vivid-scheme


### PR DESCRIPTION
Hi, this pull request adds the katy scheme.  Katy is a dark color scheme for base 16 that was inspired by Palenight and Zerodark.  Thanks.