### PR TITLE
Added Gruvbox Material scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -26,6 +26,7 @@ fruit-soda: https://github.com/jozip/base16-fruit-soda-scheme
 gigavolt: https://github.com/Whillikers/base16-gigavolt-scheme
 github: https://github.com/Defman21/base16-github-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
+gruvbox-material: https://github.com/MayushKumar/base16-gruvbox-material-scheme
 hardcore: https://github.com/callerc1/base16-hardcore-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
 helios: https://github.com/reyemxela/base16-helios-scheme


### PR DESCRIPTION
Ported the beautiful [Gruvbox Material](https://github.com/sainnhe/gruvbox-material-vscode) scheme to base16. This (in my opinion) is way soothing to the eyes than the original Gruvbox scheme.