### PR TITLE
Add gotham scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -25,6 +25,7 @@ framer: https://github.com/jssee/base16-framer-scheme
 fruit-soda: https://github.com/jozip/base16-fruit-soda-scheme
 gigavolt: https://github.com/Whillikers/base16-gigavolt-scheme
 github: https://github.com/Defman21/base16-github-scheme
+gotham: https://github.com/sboysel/base16-gotham-scheme
 gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
 hardcore: https://github.com/callerc1/base16-hardcore-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme


### PR DESCRIPTION
Adds base16 scheme for Gotham by [whatyouhide/vim-gotham](https://github.com/whatyouhide/vim-gotham).  Scheme repo is [sboysel/base16-gotham-scheme](https://github.com/sboysel/base16-gotham-scheme).