### PR TITLE
Update Horizon repo url

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -29,7 +29,7 @@ gruvbox: https://github.com/dawikur/base16-gruvbox-scheme
 hardcore: https://github.com/callerc1/base16-hardcore-scheme
 heetch: https://github.com/tealeg/base16-heetch-scheme
 helios: https://github.com/reyemxela/base16-helios-scheme
-horizon: https://github.com/michael-ball/base16-horizon-scheme
+horizon: https://git.michaelball.name/base16-horizon-scheme
 humanoid: https://github.com/humanoid-colors/base16-humanoid-schemes
 ia: https://github.com/aramisgithub/base16-ia-scheme
 icy: https://github.com/icyphox/base16-icy-scheme


### PR DESCRIPTION
The GitHub repo for the Horizon scheme is now archived and not updated anymore since it has moved elsewhere.