### PR TITLE
Re-add orphaned scheme Bright

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To add your own scheme, submit a pull request and add your repository to the lis
 * [Atelier](https://github.com/atelierbram/base16-atelier-schemes) maintained by [atelierbram](https://github.com/atelierbram)
 * [Atlas](https://github.com/ajlende/base16-atlas-scheme) maintained by [ajlende](https://github.com/ajlende)
 * [Black Metal](https://github.com/metalelf0/base16-black-metal-scheme) maintained by [metalelf0](https://github.com/metalelf0)
+* [Bright](https://gitlab.com/chtk/base16-bright) maintained by [chtk](https://gitlab.com/chtk)
 * [Brogrammer](https://github.com/piggyslasher/base16-brogrammer-scheme) maintained by [piggyslasher](https://github.com/piggyslasher)
 * [Brush Trees](https://github.com/whiteabelincoln/base16-brushtrees-scheme) maintained by [whiteabelincoln](https://github.com/whiteabelincoln)
 * [Circus](https://github.com/stepchowfun/base16-circus-scheme) maintained by [stepchowfun](https://github.com/stepchowfun) and [ewang12](https://github.com/ewang12)

--- a/list.yaml
+++ b/list.yaml
@@ -6,6 +6,7 @@ apprentice: https://github.com/casonadams/base16-apprentice-scheme
 atelier: https://github.com/atelierbram/base16-atelier-schemes
 atlas: https://github.com/ajlende/base16-atlas-scheme
 black-metal: https://github.com/metalelf0/base16-black-metal-scheme
+bright: https://gitlab.com/chtk/base16-bright
 brogrammer: https://github.com/piggyslasher/base16-brogrammer-scheme
 brushtrees: https://github.com/WhiteAbeLincoln/base16-brushtrees-scheme
 circus: https://github.com/stepchowfun/base16-circus-scheme


### PR DESCRIPTION
This scheme was apparently orphaned some time after I did my Base16 setup.  

I really like this one though. So here it is again. 