### PR TITLE
feat: fix missing solarized scheme

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -63,7 +63,7 @@ shades-of-purple: https://github.com/ahmadawais/base16-shades-of-purple
 silk: https://github.com/misterio77/base16-silk-scheme
 snazzy: https://github.com/h404bi/base16-snazzy-scheme
 solarflare: https://github.com/mnussbaum/base16-solarflare-scheme
-solarized: https://github.com/aramisgithub/base16-solarized-scheme
+solarized: https://github.com/elmotec/base16-solarized-scheme
 summercamp: https://github.com/zoefiri/base16-summercamp
 summerfruit: https://github.com/cscorley/base16-summerfruit-scheme
 synth-midnight: https://github.com/michael-ball/base16-synth-midnight-scheme


### PR DESCRIPTION
copy last version of base16-solarized-scheme from aramisgithub.