### PR TITLE
Add Moonlight color scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ To add your own scheme, submit a pull request and add your repository to the lis
 * [Material Vivid](https://github.com/joshyrobot/base16-material-vivid-scheme) maintained by [joshyrobot](https://github.com/joshyrobot)
 * [Mellow](https://github.com/gidsi/base16-mellow-scheme) maintained by [gidsi](https://github.com/gidsi)
 * [Mexico-Light](https://github.com/drzel/base16-mexico-light-scheme) maintained by [drzel](https://github.com/drzel)
+* [Moonlight](https://github.com/jswinarton/base16-moonlight-scheme) maintained by [jswinarton](https://github.com/jswinarton)
 * [Nebula](https://github.com/Misterio77/base16-nebula-scheme) maintained by [Misterio77](https://github.com/Misterio77)
 * [Nord](https://github.com/8-uh/base16-nord-scheme) maintained by [8-uh](https://github.com/8-uh)
 * [Nova](https://github.com/gessig/base16-nova-scheme) maintained by [gessig](https://github.com/gessig)

--- a/list.yaml
+++ b/list.yaml
@@ -42,6 +42,7 @@ materialtheme: https://github.com/ntpeters/base16-materialtheme-scheme
 material-vivid: https://github.com/joshyrobot/base16-material-vivid-scheme
 mellow: https://github.com/gidsi/base16-mellow-scheme
 mexico-light: https://github.com/drzel/base16-mexico-light-scheme
+moonlight: https://github.com/jswinarton/base16-moonlight-scheme
 nebula: https://github.com/Misterio77/base16-nebula-scheme
 nord: https://github.com/spejamchr/base16-nord-scheme
 nova: https://github.com/gessig/base16-nova-scheme


### PR DESCRIPTION
Hey, this PR adds a new color scheme derived from the popular [Moonlight](https://github.com/atomiks/moonlight-vscode-theme) scheme for VSCode. 

Base16 scheme is [here](https://github.com/jswinarton/base16-moonlight-scheme).