### PR TITLE
Update Windows author name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ To add your own scheme, submit a pull request and add your repository to the lis
 * [Twilight](https://github.com/hartbit/base16-twilight-scheme) maintained by [hartbit](https://github.com/hartbit)
 * [Unikitty](https://github.com/joshwlewis/base16-unikitty) maintained by [joshwlewis](https://github.com/joshwlewis)
 * [Vice](https://github.com/Thomashighbaugh/base16-vice-scheme) maintained by [Thomashighbaugh](https://github.com/Thomashighbaugh)
-* [Windows](https://github.com/C-Fergus/base16-windows-scheme) maintained by [C-Fergus](https://github.com/C-Fergus)
+* [Windows](https://github.com/ferguscollins/base16-windows-scheme) maintained by [C-Fergus](https://github.com/ferguscollins)
 * [Woodland](https://github.com/jcornwall/base16-woodland-scheme) maintained by [jcornwall](https://github.com/jcornwall)
 * [Zenburn](https://github.com/elnawe/base16-zenburn-scheme) maintained by [elnawe](https://github.com/elnawe)
 * [XCode Dust](https://github.com/gonsie/base16-xcode-dusk-scheme) maintained by [gonsie](https://github.com/gonsie)

--- a/list.yaml
+++ b/list.yaml
@@ -73,7 +73,7 @@ twilight: https://github.com/hartbit/base16-twilight-scheme
 unikitty: https://github.com/joshwlewis/base16-unikitty
 vice: https://github.com/Thomashighbaugh/base16-vice-scheme
 vulcan: https://github.com/andreyvpng/base16-vulcan-scheme
-windows: https://github.com/C-Fergus/base16-windows-scheme
+windows: https://github.com/ferguscollins/base16-windows-scheme
 woodland: https://github.com/jcornwall/base16-woodland-scheme
 xcode-dusk: https://github.com/gonsie/base16-xcode-dusk-scheme
 zenburn: https://github.com/elnawe/base16-zenburn-scheme


### PR DESCRIPTION
Changed my username from C-Fergus to ferguscollins a while back. Forgot this reference existed.

The existing link still works but there is now another user called C-Fergus so there is potential for the link to break.